### PR TITLE
benchmark: revert an accidental Buffer() -> Buffer.allocUnsafe() replace

### DIFF
--- a/benchmark/buffers/buffer-creation.js
+++ b/benchmark/buffers/buffer-creation.js
@@ -49,7 +49,7 @@ function main(conf) {
     case 'buffer()':
       bench.start();
       for (let i = 0; i < n * 1024; i++) {
-        Buffer.allocUnsafe(len);
+        Buffer(len);
       }
       bench.end(n);
       break;


### PR DESCRIPTION
I broke this line in 5ee370f4a4bf59984ef3050fed93dc4b1472bbae, sorry.
This reverts my accidental change.