### PR TITLE
test: require symlinked binary module twice

### DIFF
--- a/test/addons/symlinked-module/binding.cc
+++ b/test/addons/symlinked-module/binding.cc
@@ -1,0 +1,13 @@
+#include <node.h>
+#include <v8.h>
+
+void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
+}
+
+void init(v8::Local<v8::Object> target) {
+  NODE_SET_METHOD(target, "hello", Method);
+}
+
+NODE_MODULE(binding, init);

--- a/test/addons/symlinked-module/binding.gyp
+++ b/test/addons/symlinked-module/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/symlinked-module/submodule.js
+++ b/test/addons/symlinked-module/submodule.js
@@ -1,0 +1,9 @@
+'use strict';
+const common = require('../../common');
+const path = require('path');
+const assert = require('assert');
+
+var destDir = path.resolve(common.tmpDir);
+var mod = require(path.join(destDir, 'second', 'binding.node'));
+assert(mod != null);
+assert(mod.hello() == 'world');

--- a/test/addons/symlinked-module/test.js
+++ b/test/addons/symlinked-module/test.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../../common');
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+common.refreshTmpDir();
+
+var destDir = path.resolve(common.tmpDir);
+
+var location = [path.join(destDir, 'first'), path.join(destDir, 'second')];
+fs.mkdirSync(location[0]);
+try {
+    fs.symlinkSync(location[0], location[1]);
+} catch (EPERM) {
+    console.log('1..0 # Skipped: module identity test (no privs for symlinks)');
+    return;
+}
+
+const addonPath = path.join(__dirname, 'build', 'Release', 'binding.node');
+
+var contents = fs.readFileSync(addonPath);
+fs.writeFileSync(path.join(location[0], 'binding.node'), contents);
+fs.writeFileSync(path.join(location[1], 'binding.node'), contents);
+
+var primary = require(path.join(location[0], 'binding.node'));
+assert(primary != null);
+assert(primary.hello() == 'world');
+var secondary = require(path.join(location[1], 'binding.node'));
+assert(secondary != null);
+assert(secondary.hello() == 'world');
+var tertiary = require('./submodule');


### PR DESCRIPTION
Attempt to load the binary module disguised
behind two symlinked locations.

Big thanks to Michael Mifsud <xzyfer@gmail.com>
for preparing a proper test case.