### PR TITLE
doc: add timer classes

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -122,7 +122,8 @@ impact the performance of the event.
 
 Returns a reference to the timer object.
 
-[the Node.js Event Loop]: ../topics/the-event-loop-timers-and-nexttick.md
+[the Node.js Event Loop]: ../topics/the-event-loop-timers-and-nexttick.html
+[`Error`][]: errors.html
 [`clearImmediate`]: timers.html#timers_clearimmediate_immediateobject
 [`clearInterval`]: timers.html#timers_clearinterval_intervalobject
 [`clearTimeout`]: timers.html#timers_cleartimeout_timeoutobject

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -69,7 +69,7 @@ set to `1`.
 
 If `callback` is not a function, an [`Error`][] will be thrown.
 
-## Cancel Timers
+## Cancelling Timers
 
 The `setImmediate()`, `setInterval()`, and `setTimeout()` methods each return
 opaque objects that represent the scheduled timers. These can be used to

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -72,8 +72,8 @@ If `callback` is not a function, an [`Error`][] will be thrown.
 ## Cancelling Timers
 
 The `setImmediate()`, `setInterval()`, and `setTimeout()` methods each return
-opaque objects that represent the scheduled timers. These can be used to
-cancel the timer and prevent it from triggering.
+opaque (internally managed) objects that represent the scheduled timers. These
+can be used to cancel the timer and prevent it from triggering.
 
 ### clearImmediate(immediateObject)
 
@@ -122,7 +122,7 @@ impact the performance of the event.
 
 Returns a reference to the timer object.
 
-[the Node.js Event Loop]: ../topics/the-event-loop-timers-and-nexttick.html
+[the Node.js Event Loop]: https://github.com/nodejs/node/blob/master/doc/topics/the-event-loop-timers-and-nexttick.md
 [`Error`][]: errors.html
 [`clearImmediate`]: timers.html#timers_clearimmediate_immediateobject
 [`clearInterval`]: timers.html#timers_clearinterval_intervalobject

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -10,6 +10,42 @@ The timer functions within Node.js implement a similar API as the timers API
 provided by Web Browsers but use a different internal implementation that is
 built around [the Node.js Event Loop][].
 
+## Class: Immediate
+
+This object is created internally and is returned from [`setImmediate`][]. It
+can be passed to [`clearImmediate`] in order to cancel the scheduled actions.
+
+## Class: Timeout
+
+This object is created internally and is returned from [`setTimeout`][] and
+[`setInterval`][]. It can be passed to [`clearTimeout`][] or [`clearInterval`][]
+respectively in order to cancel the scheduled actions.
+
+By default, when a timer is scheduled using either [`setTimeout`] or
+[`setInterval`][], the Node.js event loop will continue running as long as the
+timer is active. Each of the `Timeout` objects returned by these functions
+export both `timer.ref()` and `timer.unref()` functions that can be used to
+control this default behavior.
+
+### ref()
+
+When called, requests that the Node.js event loop *not* exit so long as the
+timer is active. Calling `timer.ref()` multiple times will have no effect.
+
+Returns a reference to the `Timeout`.
+
+### unref()
+
+When called, allows the Node.js event loop to exit if the timer is the only
+item left in the Node.js event loop. Calling `timer.unref()` multiple times
+will have no effect.
+
+In the case of [`setTimeout`][], `timer.unref()` creates a separate timer that
+will wake the Node.js event loop. Creating too many of these can adversely
+impact the performance of the event.
+
+Returns a reference to the `Timeout`.
+
 ## Scheduling Timers
 
 A timer in Node.js is an internal construct that calls a given function after
@@ -71,56 +107,31 @@ If `callback` is not a function, an [`Error`][] will be thrown.
 
 ## Cancelling Timers
 
-The `setImmediate()`, `setInterval()`, and `setTimeout()` methods each return
-opaque (internally managed) objects that represent the scheduled timers. These
-can be used to cancel the timer and prevent it from triggering.
+The [`setImmediate`][], [`setInterval`][], and [`setTimeout`][] methods each
+return objects that represent the scheduled timers. These can be used to cancel
+the timer and prevent it from triggering.
 
 ### clearImmediate(immediateObject)
 
-* `immediateObject` {Object} An immediate timer object as returned by
-  `setImmediate()`.
+* `immediateObject` {Immediate} An immediate timer object as returned by
+  [`setImmediate`][].
 
 Cancels an "immediate timer".
 
 ### clearInterval(intervalObject)
 
-* `intervalObject` {Object} An interval timer object as returned by
-  `setInterval()`.
+* `intervalObject` {Timeout} An interval timer object as returned by
+  [`setInterval`][].
 
 Cancels an "interval timer".
 
 ### clearTimeout(timeoutObject)
 
-* `timeoutObject` {Object} A timeout timer object as returned by `setTimeout()`.
+* `timeoutObject` {Timeout} A timeout timer object as returned by
+  [`setTimeout`][].
 
 Cancels a "timeout timer".
 
-## Timer Reference Tracking
-
-By default, when a timer is scheduled using either `setTimeout()` or
-`setInterval()`, the Node.js event loop will continue running as long as the
-timer is active. Each of the opaque timer objects returned by these functions
-export both `timer.ref()` and `timer.unref()` functions that can be used to
-control this default behavior.
-
-### timer.ref()
-
-When called, requests that the Node.js event loop *not* exit so long as the
-timer is active. Calling `timer.ref()` multiple times will have no effect.
-
-Returns a reference to the timer object.
-
-### timer.unref()
-
-When called, allows the Node.js event loop to exit if the timer is the only
-item left in the Node.js event loop. Calling `timer.unref()` multiple times
-will have no effect.
-
-In the case of [`setTimeout`][], `timer.unref()` creates a separate timer that
-will wake the Node.js event loop. Creating too many of these can adversely
-impact the performance of the event.
-
-Returns a reference to the timer object.
 
 [the Node.js Event Loop]: https://github.com/nodejs/node/blob/master/doc/topics/the-event-loop-timers-and-nexttick.md
 [`Error`][]: errors.html

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -2,11 +2,11 @@
 
     Stability: 3 - Locked
 
-The `timer` module exposes a global API for scheduling callback functions to
-execute at some future period of time. Because the timer functions are globals,
-there is no need to call `require('timers')` to use the API.
+The `timer` module exposes a global API for scheduling functions to
+be called at some future period of time. Because the timer functions are
+globals, there is no need to call `require('timers')` to use the API.
 
-The timer functions within Node.js implement the same API as the timers API
+The timer functions within Node.js implement a similar API as the timers API
 provided by Web Browsers but use a different internal implementation that is
 built around [the Node.js Event Loop][].
 
@@ -29,8 +29,8 @@ are triggered. Returns an `immediateObject` for possible use with
 
 Callbacks for "immediate timers" are queued in the order in which they were
 created. The entire callback queue is processed every event loop iteration. If
-an immediate is queued from inside an executing callback, that immediate will
-not fire until the next event loop iteration.
+an immediate timer is queued from inside an executing callback, that timer will
+not be triggered until the next event loop iteration.
 
 If `callback` is not a function, an [`Error`][] will be thrown.
 
@@ -117,7 +117,7 @@ item left in the Node.js event loop. Calling `timer.unref()` multiple times
 will have no effect.
 
 In the case of [`setTimeout`][], `timer.unref()` creates a separate timer that
-will wake the Node.js event loop. Creating too many of these can adversely 
+will wake the Node.js event loop. Creating too many of these can adversely
 impact the performance of the event.
 
 Returns a reference to the timer object.


### PR DESCRIPTION
This is a re-do of https://github.com/nodejs/node/pull/6206 as a PR against https://github.com/nodejs/node/pull/6937.

It was easier to to simply re-do the commit than to rebase.

I made roughly the same changes as in the original commit with the addition of the following:

* Normalized references to in-document methods so that they reference each other.
* Removed the word "opaque" since documenting them makes them no longer opaque.
* Folded the "Timer Reference Tracking" section into the class description for `Timeout`.