### PR TITLE
Update quic detection and macros for OpenSSL 3.0.0-beta2-quic

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1478,7 +1478,13 @@ def configure_openssl(o):
     o['defines'] += ['OPENSSL_FIPS']
 
   if options.shared_openssl:
-    variables['openssl_quic'] = b(getsharedopensslhasquic.get_has_quic(options.__dict__['shared_openssl_includes']))
+    has_quic = getsharedopensslhasquic.get_has_quic(options.__dict__['shared_openssl_includes'])
+  else:
+    has_quic = getsharedopensslhasquic.get_has_quic('deps/openssl/openssl/include')
+
+  variables['openssl_quic'] = b(has_quic)
+  if has_quic:
+    o['defines'] += ['NODE_OPENSSL_HAS_QUIC']
 
   configure_library('openssl', o)
 

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -27,8 +27,8 @@
 #include "base_object.h"
 #include "v8.h"
 
-#if HAVE_OPENSSL
-# include <openssl/crypto.h>
+#if NODE_OPENSSL_HAS_QUIC
+#include <openssl/quic.h>
 #endif
 
 #include <cstdint>
@@ -107,7 +107,7 @@ namespace node {
 #define NODE_ASYNC_INSPECTOR_PROVIDER_TYPES(V)
 #endif  // HAVE_INSPECTOR
 
-#ifdef OPENSSL_INFO_QUIC
+#if NODE_OPENSSL_HAS_QUIC
 #define NODE_ASYNC_QUIC_PROVIDER_TYPES(V)                                     \
   V(BLOBSOURCE)                                                               \
   V(JSQUICBUFFERCONSUMER)                                                     \

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -11,6 +11,9 @@
 
 #if HAVE_OPENSSL
 #include <openssl/opensslv.h>
+#if NODE_OPENSSL_HAS_QUIC
+#include <openssl/quic.h>
+#endif
 #endif  // HAVE_OPENSSL
 
 #ifdef OPENSSL_INFO_QUIC

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -8,6 +8,9 @@
 
 #if HAVE_OPENSSL
 #include <openssl/crypto.h>
+#if NODE_OPENSSL_HAS_QUIC
+#include <openssl/quic.h>
+#endif
 #endif  // HAVE_OPENSSL
 
 namespace node {

--- a/src/quic/quic.cc
+++ b/src/quic/quic.cc
@@ -3,14 +3,14 @@
 #include <openssl/crypto.h>
 #endif  // HAVE_OPENSSL
 
-#ifdef OPENSSL_INFO_QUIC
+#if NODE_OPENSSL_HAS_QUIC
 # include "quic/quic.h"
 # include "quic/endpoint.h"
 # include "quic/session.h"
 # include "quic/stream.h"
 # include "crypto/crypto_random.h"
 # include "crypto/crypto_context.h"
-#endif  // OPENSSL_INFO_QUIC
+#endif  // NODE_OPENSSL_HAS_QUIC
 
 #include "async_wrap-inl.h"
 #include "base_object-inl.h"
@@ -36,7 +36,7 @@ using v8::String;
 using v8::Value;
 
 namespace quic {
-#ifdef OPENSSL_INFO_QUIC
+#if NODE_OPENSSL_HAS_QUIC
 
 constexpr FastStringKey BindingState::type_name;
 
@@ -335,14 +335,14 @@ void CreateSecureContext(const FunctionCallbackInfo<Value>& args) {
 }
 }  // namespace
 
-#endif  // OPENSSL_INFO_QUIC
+#endif  // NODE_OPENSSL_HAS_QUIC
 
 void Initialize(
     Local<Object> target,
     Local<Value> unused,
     Local<Context> context,
     void* priv) {
-#ifdef OPENSSL_INFO_QUIC
+#if NODE_OPENSSL_HAS_QUIC
   Environment* env = Environment::GetCurrent(context);
 
   if (UNLIKELY(!BindingState::Initialize(env, target)))
@@ -397,7 +397,7 @@ void Initialize(
   NODE_DEFINE_CONSTANT(target, NGHTTP3_H3_NO_ERROR);
   NODE_DEFINE_CONSTANT(target, QUICERROR_TYPE_TRANSPORT);
   NODE_DEFINE_CONSTANT(target, QUICERROR_TYPE_APPLICATION);
-#endif  // OPENSSL_INFO_QUIC
+#endif  // NODE_OPENSSL_HAS_QUIC
 }
 
 }  // namespace quic

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -7,7 +7,11 @@
 #include "quic/session.h"
 #include "quic/stream.h"
 #include "crypto/crypto_common.h"
+#if OPENSSL_VERSION_MAJOR >= 3
+#include "openssl/x509.h"
+#else
 #include "crypto/x509.h"
+#endif
 #include "aliased_struct-inl.h"
 #include "async_wrap-inl.h"
 #include "base_object-inl.h"

--- a/tools/getsharedopensslhasquic.py
+++ b/tools/getsharedopensslhasquic.py
@@ -4,12 +4,15 @@ import re
 
 def get_has_quic(include_path):
   if include_path:
-    openssl_crypto_h = os.path.join(
+    openssl_quic_h = os.path.join(
         include_path,
         'openssl',
-        'crypto.h')
+        'quic.h')
 
-    f = open(openssl_crypto_h)
+    try:
+      f = open(openssl_quic_h)
+    except OSError:
+      return False
 
     regex = '^#\s*define OPENSSL_INFO_QUIC'
 


### PR DESCRIPTION
These commits allowed me to compile against OpenSSL 3.0.0-beta2-quic. 

I ran into the same compilation errors are reported [here](https://github.com/nodejs/node/pull/38233#issuecomment-903269677) before applying these commits. There is a failing test that I've not addressed:
```console
=== release test-quic-simple-response ===                                     
Path: parallel/test-quic-simple-response
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected

+ 'self-signed certificate'
- 'self signed certificate'
       ^
    at /home/danielbevenius/work/nodejs/node/test/parallel/test-quic-simple-response.js:213:10
    at /home/danielbevenius/work/nodejs/node/test/common/index.js:394:15 {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: 'self-signed certificate',
  expected: 'self signed certificate',
  operator: 'strictEqual'
}
Command: out/Release/node --no-warnings /home/danielbevenius/work/nodejs/node/test/parallel/test-quic-simple-response.js
```